### PR TITLE
Don't assume slt-fsp-pass-strength-result is set.

### DIFF
--- a/slt-force-strong-passwords.php
+++ b/slt-force-strong-passwords.php
@@ -124,7 +124,7 @@ function slt_fsp_validate_strong_password( $errors, $user_data ) {
 		if ( SLT_FSP_USE_ZXCVBN ) {
 
 			// Check the strength passed from the zxcvbn meter
-			if ( $_POST['slt-fsp-pass-strength-result'] != __( 'Strong' ) ) {
+			if ( ! empty( $_POST['slt-fsp-pass-strength-result'] ) && $_POST['slt-fsp-pass-strength-result'] != __( 'Strong' ) ) {
 				$password_ok = false;
 			}
 


### PR DESCRIPTION
This fixes an issue we're having when users try to use your plugin with iTheme's Exchange. You shouldn't assume that your POST key is set as other plugins may access the WP function from elsewhere.

In our example, its being called via AJAX and the PHP warning is breaking the json for the callback.

Thanks!
