### PR TITLE
Encode before comapring

### DIFF
--- a/slt-force-strong-passwords.php
+++ b/slt-force-strong-passwords.php
@@ -126,7 +126,8 @@ function slt_fsp_validate_strong_password( $errors, $user_data ) {
 		if ( SLT_FSP_USE_ZXCVBN ) {
 
 			// Check the strength passed from the zxcvbn meter
-			if ( ! empty( $_POST['slt-fsp-pass-strength-result'] ) && $_POST['slt-fsp-pass-strength-result'] != __( 'Strong' ) ) {
+			$compare = html_entity_decode( __( 'Strong' ), ENT_QUOTES, 'UTF-8');
+			if ( ! empty( $_POST['slt-fsp-pass-strength-result'] ) && $_POST['slt-fsp-pass-strength-result'] != $compare ) {
 				$password_ok = false;
 			}
 


### PR DESCRIPTION
With certain non-English languages, characters within the string that is being used for comparison could be HTML encoded (see `WP_Scripts::localize()` in `wp-includes/class.wp-scripts.php`). This change ensures that we're checking the encoded string, which prevents false negatives.
