### PR TITLE
Force strong passwords from network admin screens

### DIFF
--- a/slt-force-strong-passwords.php
+++ b/slt-force-strong-passwords.php
@@ -167,6 +167,12 @@ function slt_fsp_validate_strong_password( $errors, $user_data ) {
  */
 function slt_fsp_enforce_for_user( $user_id ) {
 	$enforce = true;
+
+	// force strong passwords from network admin screens
+	if(is_network_admin()) {
+		return $enforce;
+	}
+
 	$check_caps = explode( ',', SLT_FSP_CAPS_CHECK );
 	$check_caps = apply_filters( 'slt_fsp_caps_check', $check_caps );
 	$check_caps = (array) $check_caps;


### PR DESCRIPTION
Hi,

This PR is a proposal to fix the bug #2 

Wordpress capabilities are affected on a per blog basis. Calling user_can from a network admin screen is pointless because there is no blog context, so no caps.

A choice must be made here. Force strong passwords on admin screens, regardless of user capabilities, or cross every blog to check caps. Checking on every blog might cause performance problems or worst (exec time exceed) when fired on very large networks.

In my PR, i chose to simply force strong passwords from network admin screens as only power users can access it and if they chose to use this plugin, they surely want strong passwords to be used.
